### PR TITLE
Add entry for libnewmat10-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2657,6 +2657,9 @@ libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
   gentoo: [net-libs/neon]
   ubuntu: [libneon27-gnutls-dev]
+libnewmat10-dev:
+  debian: [libnewmat10-dev]
+  ubuntu: [libnewmat10-dev]
 libnl-3:
   arch: [libnl]
   debian: [libnl-3-200, libnl-genl-3-200]


### PR DESCRIPTION
add entry for libnewmat10-dev - Only ubuntu and debian